### PR TITLE
fix: reps input resets when user clears value

### DIFF
--- a/src/components/dashboard/quick-log-form.tsx
+++ b/src/components/dashboard/quick-log-form.tsx
@@ -301,7 +301,7 @@ const QuickLogFormComponent = forwardRef<QuickLogFormHandle, QuickLogFormProps>(
                               )
                             }
                             value={field.value ?? ""}
-                            placeholder={suggestion?.reps?.toString() ?? "0"}
+                            placeholder={suggestion?.reps?.toFixed(0) ?? "0"}
                             className="w-full"
                             disabled={form.formState.isSubmitting}
                             data-testid="quick-log-reps-input"


### PR DESCRIPTION
## Summary

- Fix bug where reps input fights with user when clearing value
- Remove auto-fill useEffect that re-populated on `undefined` 
- Show suggestion as placeholder text instead of auto-filling

## Problem

When selecting an exercise, reps auto-filled to suggestion (e.g., 21). When user tried to delete digits to enter a different value, clearing the field triggered re-population because `reps === undefined` condition passed again.

## Solution

Replace auto-fill with placeholder-based suggestions:
- Deleted 17-line auto-fill useEffect
- Reps/weight placeholders now show suggestion value
- Input state is fully user-controlled
- Suggestions display as gray hint text

## Behavior After Fix

1. Select "Push-ups" (last set: 20 reps) → placeholder shows "21" in gray
2. Type "15" → placeholder disappears, shows your value
3. Clear input → placeholder "21" reappears as hint
4. No more fighting when clearing/editing values

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test --run src/components/dashboard/quick-log-form.test.tsx` passes (6 tests)
- [ ] Manual test: select exercise, verify placeholder shows suggestion
- [ ] Manual test: type value, verify it persists
- [ ] Manual test: clear value, verify placeholder reappears (no reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented suggested values from being auto-populated into form inputs; fields no longer overwrite user input.

* **Style**
  * Placeholders for Reps and Weight now show suggested values (formatted) when available, otherwise display "0".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->