### PR TITLE
fix: add changeset for setup-node v6 bump

### DIFF
--- a/.changeset/bump-setup-node-v6.md
+++ b/.changeset/bump-setup-node-v6.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(deps): bump actions/setup-node from 4 to 6


### PR DESCRIPTION
## Summary
- Adds empty changeset to satisfy CI changeset requirement

The CI workflow requires a changeset file for all PRs, but PR #22 (Dependabot's setup-node bump) only changes workflow YAML files. This fix adds an empty changeset to pass the check.

## Root Cause
The `pnpm changeset status --since=origin/master` check failed because no changeset was present. For dependency bumps affecting only CI workflows (not source code), an empty changeset is appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)