### PR TITLE
fix(a11y): remove empty heading that confused screen readers

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -52,11 +52,8 @@ export function Footer() {
             </a>
           </div>
 
-          {/* Copyright Section */}
-          <div className="space-y-2">
-            <h3 className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-              &nbsp;
-            </h3>
+          {/* Copyright Section - no heading, aligned with other sections' content */}
+          <div className="pt-6">
             <div className="font-mono text-sm text-muted-foreground space-y-0.5">
               <p>© {currentYear} Volume</p>
               <p className="text-xs text-muted-foreground/80">v{version}</p>


### PR DESCRIPTION
## Summary

- Removed empty `<h3>` heading with `&nbsp;` that screen readers announced as "heading with no label"
- Used `pt-6` padding to maintain visual alignment with other footer columns
- Improves accessibility for users relying on screen readers

## Test plan

- [x] TypeScript passes (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [x] All 775 tests pass (`pnpm test --run`)
- [ ] Manual: Verify footer visual alignment unchanged
- [ ] Manual: Verify screen reader no longer announces empty heading

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated footer layout by removing the section heading and adjusting spacing for improved visual alignment. Copyright and version information remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->