### PR TITLE
feat: add useUndoableAction hook for centralized undo pattern

### DIFF
--- a/src/components/dashboard/exercise-set-group.tsx
+++ b/src/components/dashboard/exercise-set-group.tsx
@@ -127,8 +127,10 @@ export function ExerciseSetGroup({
 
     setDeletingId(setToDelete._id);
     try {
-      await executeDelete(setToDelete);
-      setSetToDelete(null);
+      const success = await executeDelete(setToDelete);
+      if (success) {
+        setSetToDelete(null);
+      }
     } finally {
       setDeletingId(null);
     }

--- a/src/hooks/useUndoableAction.ts
+++ b/src/hooks/useUndoableAction.ts
@@ -30,8 +30,8 @@ export interface UndoableActionConfig<TData, TItem> {
 }
 
 export interface UndoableActionResult<TItem> {
-  /** Execute the action with undo support */
-  execute: (item: TItem) => Promise<void>;
+  /** Execute the action with undo support. Returns true on success, false on failure. */
+  execute: (item: TItem) => Promise<boolean>;
 
   /** Whether an action is currently in progress */
   isPending: boolean;
@@ -81,7 +81,7 @@ export function useUndoableAction<TData, TItem>(
   const [isPending, setIsPending] = useState(false);
 
   const execute = useCallback(
-    async (item: TItem) => {
+    async (item: TItem): Promise<boolean> => {
       setIsPending(true);
       try {
         // Capture state BEFORE action executes
@@ -102,9 +102,10 @@ export function useUndoableAction<TData, TItem>(
             },
           },
         });
+        return true;
       } catch (error) {
         onActionError?.(error);
-        // Don't re-throw - error handler is responsible for user feedback
+        return false;
       } finally {
         setIsPending(false);
       }


### PR DESCRIPTION
## Summary

- Extract `useUndoableAction` hook for centralized undo-delete pattern
- Refactor `ExerciseSetGroup` to use the new hook, reducing boilerplate
- Add comprehensive tests (11 test cases covering happy path, errors, edge cases)

This establishes a consistent pattern for future undo-enabled destructive actions.

## Test plan

- [x] All 786 tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint passes with 0 warnings
- [x] Production build succeeds
- [ ] Manual test: delete a set, verify undo toast appears
- [ ] Manual test: click undo within 5s, verify set is restored
- [ ] Manual test: verify error handling when delete fails

Closes #256

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved undo for deleted exercise sets: deletions show a toast with a configurable undo window and more reliable restore behavior.
* **Bug Fixes**
  * More robust error handling around delete/restore flows to prevent failed restores from disrupting the UI.
* **Tests**
  * Comprehensive test coverage added for the undoable delete workflow and undo timing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->