### PR TITLE
fix: increase touch target sizes for exercise selector on mobile

### DIFF
--- a/src/components/dashboard/exercise-selector-dialog.tsx
+++ b/src/components/dashboard/exercise-selector-dialog.tsx
@@ -77,12 +77,13 @@ const commandList = (
     />
     <CommandList className={options?.listClassName}>
       <CommandEmpty>
-        <div className="flex flex-col gap-3 p-3">
+        <div className="flex flex-col gap-4 p-4">
           <span className="text-sm text-muted-foreground">
             No exercises found.
           </span>
           <BrutalistButton
             variant="outline"
+            className="min-h-[44px]"
             onClick={() => {
               close();
               onCreateNew();
@@ -93,7 +94,7 @@ const commandList = (
           </BrutalistButton>
         </div>
       </CommandEmpty>
-      <CommandGroup>
+      <CommandGroup className="[&_[cmdk-group-items]]:flex [&_[cmdk-group-items]]:flex-col [&_[cmdk-group-items]]:gap-1">
         {exercises.map((exercise) => (
           <CommandItem
             key={exercise._id}
@@ -103,14 +104,15 @@ const commandList = (
               close();
             }}
             data-testid={`exercise-option-${exercise._id}`}
+            className="min-h-[44px] px-3 py-2.5 text-base touch-manipulation"
           >
             <Check
               className={cn(
-                "mr-2 h-4 w-4",
+                "mr-3 h-5 w-5 shrink-0",
                 selectedId === exercise._id ? "opacity-100" : "opacity-0"
               )}
             />
-            {exercise.name}
+            <span className="truncate">{exercise.name}</span>
           </CommandItem>
         ))}
         <CommandItem
@@ -119,7 +121,7 @@ const commandList = (
             close();
             onCreateNew();
           }}
-          className="border-t"
+          className="border-t-2 min-h-[44px] px-3 py-2.5 text-base font-medium touch-manipulation mt-1"
           data-testid="exercise-create-new"
         >
           + Create New
@@ -172,8 +174,9 @@ export function ExerciseSelectorDialog({
                 size="icon"
                 aria-label="Close"
                 data-testid="exercise-dialog-close"
+                className="h-11 w-11 min-h-[44px] min-w-[44px]"
               >
-                <X className="h-4 w-4" />
+                <X className="h-5 w-5" />
               </BrutalistButton>
             </DialogClose>
           </div>


### PR DESCRIPTION
## Summary
Addresses issue #268: Exercise selection options are too small for mobile.

## Changes

### Touch targets (44px minimum per Apple HIG)
- Exercise list items: `min-h-[44px]`, `px-3 py-2.5`, `text-base`
- Create New button: Same sizing, plus `font-medium` emphasis
- Close button (mobile): `h-11 w-11 min-h-[44px] min-w-[44px]`
- Empty state create button: `min-h-[44px]`

### Spacing improvements
- CommandGroup: Flex column with `gap-1` between items
- Empty state: Increased to `gap-4 p-4`
- Checkmark icon: `h-5 w-5` with `mr-3` spacing

### Mobile responsiveness
- Added `touch-manipulation` for better touch response
- Exercise names wrapped in `truncate` span for long names

## Testing
- Works on both mobile (Dialog) and desktop (Popover)
- Touch targets meet Apple HIG minimum of 44x44px

Closes #268

---
*Overnight builder: mobile UX improvements while you sleep* 📱

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined exercise selector dialog UI with improved spacing, padding, and visual hierarchy.
  * Enhanced icon sizing and updated layout responsiveness for mobile and desktop views.
  * Improved empty state presentation with clearer spacing and better touch interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->