### PR TITLE
chore: sync lefthook hook shims

### DIFF
--- a/.husky/_/commit-msg
+++ b/.husky/_/commit-msg
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif [ -f /opt/homebrew/bin/lefthook ] && /opt/homebrew/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /opt/homebrew/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif [ -f /opt/homebrew/bin/lefthook ] && /opt/homebrew/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /opt/homebrew/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif [ -f /opt/homebrew/bin/lefthook ] && /opt/homebrew/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /opt/homebrew/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif [ -f /opt/homebrew/bin/lefthook ] && /opt/homebrew/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/phaedrus/Development/volume/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /opt/homebrew/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Summary
- sync generated `.husky/_/*` hook shims with Homebrew fallback path
- keep hook wrappers aligned with current local/project Lefthook behavior

## Why
- these 4 files were persistent local drift
- fallback to `/opt/homebrew/bin/lefthook` reduces hook failures when global Lefthook is installed there

## What changed
- `.husky/_/commit-msg`: add Homebrew lefthook fallback branch
- `.husky/_/post-checkout`: add Homebrew lefthook fallback branch
- `.husky/_/pre-commit`: add Homebrew lefthook fallback branch
- `.husky/_/pre-push`: add Homebrew lefthook fallback branch

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test --run`
- `bun run build`
- pre-push hook suite passed (`build-check`, `test-suite`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Husky git hooks to detect and run Lefthook from additional installation locations.
  * Improved hook reliability by adding fallback detection and execution for alternative Lefthook binaries.
  * Updated commit-msg, post-checkout, pre-commit, and pre-push hooks to use these additional fallbacks.
  * No changes to exported or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Before / After

**Before:** PR introduced machine-specific `/Users/phaedrus/...` lefthook fallback paths in `.husky/_/*`, triggering portability failures and Cerberus FAIL.

**After:** Replaced machine-specific paths with portable Homebrew fallback checks (`[ -f /opt/homebrew/bin/lefthook ] && /opt/homebrew/bin/lefthook -h ...`) across all 4 hook shims. Resolved all review threads tied to the issue.

**Screenshots:** Not applicable (internal hook shim change; no UI/visual delta).