### PR TITLE
feat(coach): add exercise ticker chiron to agent workspace

### DIFF
--- a/convex/sets.ts
+++ b/convex/sets.ts
@@ -419,3 +419,68 @@ export const editSet = mutation({
     await ctx.db.patch(args.id, patch);
   },
 });
+
+// Aggregated exercise summaries for today (used by exercise ticker)
+export const getTodayExerciseSummary = query({
+  args: {
+    dayStartMs: v.number(),
+    dayEndMs: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+
+    const sets = await ctx.db
+      .query("sets")
+      .withIndex("by_user_performed", (q) =>
+        q
+          .eq("userId", identity.subject)
+          .gte("performedAt", args.dayStartMs)
+          .lte("performedAt", args.dayEndMs)
+      )
+      .collect();
+
+    if (sets.length === 0) return [];
+
+    // Group by exercise
+    const byExercise = new Map<
+      string,
+      {
+        exerciseId: (typeof sets)[0]["exerciseId"];
+        totalSets: number;
+        totalReps: number;
+        totalWeight: number;
+      }
+    >();
+    for (const set of sets) {
+      const key = set.exerciseId;
+      const agg = byExercise.get(key) ?? {
+        exerciseId: key,
+        totalSets: 0,
+        totalReps: 0,
+        totalWeight: 0,
+      };
+      agg.totalSets += 1;
+      agg.totalReps += set.reps ?? 0;
+      if (set.weight) agg.totalWeight += set.weight * (set.reps ?? 1);
+      byExercise.set(key, agg);
+    }
+
+    // Resolve exercise names
+    const results = [];
+    for (const agg of byExercise.values()) {
+      const exercise = await ctx.db.get(agg.exerciseId);
+      if (!exercise) continue;
+      results.push({
+        exerciseId: agg.exerciseId,
+        name: exercise.name,
+        muscleGroups: exercise.muscleGroups ?? [],
+        totalSets: agg.totalSets,
+        totalReps: agg.totalReps,
+        totalWeight: agg.totalWeight,
+      });
+    }
+
+    return results;
+  },
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -198,3 +198,16 @@
   0%, 100% { filter: invert(0); }
   50% { filter: invert(1); }
 }
+
+@keyframes ticker-scroll {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+.ticker-track {
+  animation: ticker-scroll 30s linear infinite;
+}
+
+.ticker-track:hover {
+  animation-play-state: paused;
+}

--- a/src/components/coach/CoachPrototype.tsx
+++ b/src/components/coach/CoachPrototype.tsx
@@ -12,6 +12,7 @@ import ReactMarkdown from "react-markdown";
 import { useJsonRenderMessage } from "@json-render/react";
 import { PaperPlaneIcon, ReloadIcon } from "@radix-ui/react-icons";
 import { CoachSpecRenderer } from "@/components/coach/CoachBlockRenderer";
+import { ExerciseTicker } from "@/components/coach/ExerciseTicker";
 import { useCoachChat } from "@/components/coach/useCoachChat";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "ai";
@@ -175,15 +176,16 @@ export function CoachPrototype() {
       : -1;
 
   return (
-    <main className="relative mx-auto flex w-full max-w-4xl flex-1 min-h-0 flex-col px-3 pt-3 pb-2 md:px-4 md:pb-6">
-      <p className="mb-2 px-1 text-xs text-muted-foreground">
+    <main className="relative mx-auto flex w-full max-w-4xl flex-1 min-h-0 flex-col pb-2 md:pb-6">
+      <ExerciseTicker />
+      <p className="mb-2 px-4 pt-3 text-xs text-muted-foreground md:px-4">
         Try &quot;12 pushups&quot;, &quot;show today&apos;s summary&quot;, or
         ask for insights.
       </p>
 
       <section
         data-testid="coach-timeline"
-        className="flex-1 min-h-0 space-y-2 overflow-y-auto pb-4 pr-1"
+        className="flex-1 min-h-0 space-y-2 overflow-y-auto px-3 pb-4 pr-1 md:px-4"
       >
         {messages.length === 0 && !isWorking && (
           <article className="flex justify-start">
@@ -239,7 +241,7 @@ export function CoachPrototype() {
       <form
         onSubmit={handleSubmit}
         data-testid="coach-composer"
-        className="border-t border-border-subtle bg-card p-[8px] pb-[calc(8px+env(safe-area-inset-bottom,0px))] sticky bottom-0"
+        className="mx-3 border-t border-border-subtle bg-card p-[8px] pb-[calc(8px+env(safe-area-inset-bottom,0px))] sticky bottom-0 md:mx-4"
         style={{ bottom: `${keyboardOffset}px` }}
       >
         <div className="flex items-center gap-2">

--- a/src/components/coach/ExerciseTicker.tsx
+++ b/src/components/coach/ExerciseTicker.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+
+/** Map primary muscle group → emoji icon */
+function muscleIcon(groups: string[]): string {
+  const primary = groups[0];
+  switch (primary) {
+    case "Chest":
+      return "🏋️";
+    case "Back":
+      return "🔙";
+    case "Shoulders":
+    case "Biceps":
+    case "Triceps":
+      return "💪";
+    case "Quads":
+    case "Hamstrings":
+    case "Glutes":
+    case "Calves":
+      return "🦵";
+    case "Core":
+      return "🧘";
+    default:
+      return "⚡";
+  }
+}
+
+function formatAggregate(item: {
+  totalSets: number;
+  totalReps: number;
+  totalWeight: number;
+}): string {
+  const parts: string[] = [`${item.totalSets}s`];
+  if (item.totalReps > 0) parts.push(`${item.totalReps}r`);
+  if (item.totalWeight > 0)
+    parts.push(`${Math.round(item.totalWeight).toLocaleString()} vol`);
+  return parts.join(" · ");
+}
+
+function getDayBounds(): { dayStartMs: number; dayEndMs: number } {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { dayStartMs: start.getTime(), dayEndMs: end.getTime() - 1 };
+}
+
+export function ExerciseTicker() {
+  const { dayStartMs, dayEndMs } = getDayBounds();
+  const summary = useQuery(api.sets.getTodayExerciseSummary, {
+    dayStartMs,
+    dayEndMs,
+  });
+
+  if (!summary || summary.length === 0) return null;
+
+  const items = summary;
+
+  // ~8s per exercise so speed feels consistent regardless of item count
+  const durationSeconds = Math.max(12, items.length * 8);
+
+  const renderItem = (
+    item: (typeof items)[number],
+    idx: number,
+    keyPrefix: string
+  ) => (
+    <span
+      key={`${keyPrefix}-${idx}`}
+      className="inline-flex items-center gap-1.5 whitespace-nowrap px-3"
+    >
+      <span className="text-sm">{muscleIcon(item.muscleGroups)}</span>
+      <span className="text-xs font-semibold text-foreground">{item.name}</span>
+      <span className="text-[11px] tabular-nums text-muted-foreground">
+        {formatAggregate(item)}
+      </span>
+      <span className="ml-3 text-muted-foreground/40 select-none" aria-hidden>
+        ▸
+      </span>
+    </span>
+  );
+
+  return (
+    <div
+      className="relative w-full overflow-hidden border-b border-border-subtle bg-card/60 backdrop-blur-sm"
+      aria-label="Today's exercise summary"
+      role="marquee"
+    >
+      <div
+        className="ticker-track flex w-max items-center py-1.5"
+        style={{ animationDuration: `${durationSeconds}s` }}
+      >
+        <div className="flex shrink-0 items-center">
+          {items.map((item, idx) => renderItem(item, idx, "a"))}
+        </div>
+        <div className="flex shrink-0 items-center" aria-hidden>
+          {items.map((item, idx) => renderItem(item, idx, "b"))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Real-time scrolling ticker below the navbar showing today's exercises
with muscle group icons, set/rep counts, and volume aggregates.
Auto-scrolls like a news chiron, pauses on hover.

- New Convex query `getTodayExerciseSummary` aggregates today's sets by exercise
- New `ExerciseTicker` component with CSS marquee animation
- Dynamic scroll speed scales with item count (~8s per exercise)

https://claude.ai/code/session_01YMLtzuiUYUiFajStYGjkDf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an exercise ticker displaying today's completed exercises at the top of the coach screen with exercise emojis, names, and aggregate statistics (total sets, reps, and localized volume measurements).
  * Ticker features continuous horizontal scrolling with automatic pause on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->