### PR TITLE
refactor: unify coach summary serialization via toTodayTotalsOutput

### DIFF
--- a/src/lib/coach/tools/helpers.test.ts
+++ b/src/lib/coach/tools/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   formatSecondsShort,
   normalizeLookup,
   titleCase,
+  toTodayTotalsOutput,
   uniquePrompts,
 } from "./helpers";
 
@@ -48,6 +49,84 @@ describe("helpers", () => {
         "c",
         "d",
       ]);
+    });
+  });
+
+  describe("toTodayTotalsOutput", () => {
+    it("serializes all fields to snake_case", () => {
+      const output = toTodayTotalsOutput({
+        totalSets: 5,
+        totalReps: 50,
+        totalDurationSeconds: 120,
+        exerciseCount: 2,
+        topExercises: [
+          {
+            exerciseId: "ex1",
+            exerciseName: "Bench",
+            sets: 3,
+            reps: 30,
+            durationSeconds: 0,
+          },
+          {
+            exerciseId: "ex2",
+            exerciseName: "Plank",
+            sets: 2,
+            reps: 0,
+            durationSeconds: 120,
+          },
+        ],
+      });
+
+      expect(output).toEqual({
+        total_sets: 5,
+        total_reps: 50,
+        total_duration_seconds: 120,
+        exercise_count: 2,
+        top_exercises: [
+          { exercise_name: "Bench", sets: 3, reps: 30, duration_seconds: null },
+          {
+            exercise_name: "Plank",
+            sets: 2,
+            reps: null,
+            duration_seconds: 120,
+          },
+        ],
+      });
+    });
+
+    it("returns empty top_exercises for zero-set day", () => {
+      const output = toTodayTotalsOutput({
+        totalSets: 0,
+        totalReps: 0,
+        totalDurationSeconds: 0,
+        exerciseCount: 0,
+        topExercises: [],
+      });
+
+      expect(output.total_sets).toBe(0);
+      expect(output.total_duration_seconds).toBe(0);
+      expect(output.top_exercises).toEqual([]);
+    });
+
+    it("nullifies zero reps and zero duration in top_exercises", () => {
+      const output = toTodayTotalsOutput({
+        totalSets: 1,
+        totalReps: 0,
+        totalDurationSeconds: 0,
+        exerciseCount: 1,
+        topExercises: [
+          {
+            exerciseId: "ex1",
+            exerciseName: "Test",
+            sets: 1,
+            reps: 0,
+            durationSeconds: 0,
+          },
+        ],
+      });
+
+      expect(output.top_exercises[0]?.reps).toBeNull();
+      expect(output.top_exercises[0]?.duration_seconds).toBeNull();
     });
   });
 

--- a/src/lib/coach/tools/helpers.ts
+++ b/src/lib/coach/tools/helpers.ts
@@ -128,11 +128,19 @@ export function exerciseNotFoundResult(
   };
 }
 
-/** Snake-case model-output shape for today's totals. */
+/** Snake-case model-output shape for today's totals — single source of truth. */
 export function toTodayTotalsOutput(totals: TodayTotalsSummary) {
   return {
     total_sets: totals.totalSets,
     total_reps: totals.totalReps,
+    total_duration_seconds: totals.totalDurationSeconds,
     exercise_count: totals.exerciseCount,
+    top_exercises: totals.topExercises.map((entry) => ({
+      exercise_name: entry.exerciseName,
+      sets: entry.sets,
+      reps: entry.reps > 0 ? entry.reps : null,
+      duration_seconds:
+        entry.durationSeconds > 0 ? entry.durationSeconds : null,
+    })),
   };
 }

--- a/src/lib/coach/tools/tool-bulk-log.test.ts
+++ b/src/lib/coach/tools/tool-bulk-log.test.ts
@@ -98,7 +98,9 @@ describe("runBulkLogTool", () => {
     expect(result.outputForModel.today_totals).toEqual({
       total_sets: 0,
       total_reps: 0,
+      total_duration_seconds: 0,
       exercise_count: 0,
+      top_exercises: [],
     });
     expect((result.blocks[0] as any).title).toBe("All sets logged");
   });

--- a/src/lib/coach/tools/tool-log-set.test.ts
+++ b/src/lib/coach/tools/tool-log-set.test.ts
@@ -61,7 +61,16 @@ describe("runLogSetTool", () => {
     expect(result.outputForModel.today_totals).toEqual({
       total_sets: 3,
       total_reps: 30,
+      total_duration_seconds: 0,
       exercise_count: 1,
+      top_exercises: [
+        {
+          exercise_name: "Push-ups",
+          sets: 3,
+          reps: 30,
+          duration_seconds: null,
+        },
+      ],
     });
   });
 
@@ -97,7 +106,16 @@ describe("runLogSetTool", () => {
     expect(result.outputForModel.today_totals).toEqual({
       total_sets: 5,
       total_reps: 50,
+      total_duration_seconds: 0,
       exercise_count: 1,
+      top_exercises: [
+        {
+          exercise_name: "Bench Press",
+          sets: 5,
+          reps: 50,
+          duration_seconds: null,
+        },
+      ],
     });
   });
 

--- a/src/lib/coach/tools/tool-today-summary.test.ts
+++ b/src/lib/coach/tools/tool-today-summary.test.ts
@@ -50,6 +50,8 @@ describe("runTodaySummaryTool", () => {
     expect(result.outputForModel.surface).toBe("today_empty");
     expect(result.outputForModel.title).toBe("No sets logged today");
     expect(result.outputForModel.total_sets).toBe(0);
+    expect(result.outputForModel.total_duration_seconds).toBe(0);
+    expect(result.outputForModel.top_exercises).toEqual([]);
   });
 
   it("non-empty sets -> first block is metrics", async () => {

--- a/src/lib/coach/tools/tool-today-summary.ts
+++ b/src/lib/coach/tools/tool-today-summary.ts
@@ -48,32 +48,15 @@ function buildTodaySummaryBlocks(summary: TodayTotalsSummary): CoachBlock[] {
 }
 
 function buildTodaySummaryOutput(summary: TodayTotalsSummary) {
-  if (summary.totalSets === 0) {
-    return {
-      status: "ok",
-      surface: "today_empty",
-      title: "No sets logged today",
-      description: "Log one now and I will generate your daily focus.",
-      ...toTodayTotalsOutput(summary),
-      total_duration_seconds: summary.totalDurationSeconds,
-      top_exercises: [],
-    };
-  }
-
+  const isEmpty = summary.totalSets === 0;
   return {
     status: "ok",
-    surface: "today_summary",
-    title: "Today's totals",
-    top_exercises_title: "Top exercises today",
+    surface: isEmpty ? "today_empty" : "today_summary",
+    title: isEmpty ? "No sets logged today" : "Today's totals",
+    ...(isEmpty
+      ? { description: "Log one now and I will generate your daily focus." }
+      : { top_exercises_title: "Top exercises today" }),
     ...toTodayTotalsOutput(summary),
-    total_duration_seconds: summary.totalDurationSeconds,
-    top_exercises: summary.topExercises.map((entry) => ({
-      exercise_name: entry.exerciseName,
-      sets: entry.sets,
-      reps: entry.reps > 0 ? entry.reps : null,
-      duration_seconds:
-        entry.durationSeconds > 0 ? entry.durationSeconds : null,
-    })),
   };
 }
 


### PR DESCRIPTION
toTodayTotalsOutput was a lossy serializer — it dropped
totalDurationSeconds and topExercises. The today-summary tool manually
added them back, but log-set and bulk-log did not, causing the model to
receive incomplete summary data after logging sets.

Now toTodayTotalsOutput is the single source of truth for
TodayTotalsSummary → snake_case model output. All three tools get
consistent, complete data. buildTodaySummaryOutput is simplified to
just add surface/title metadata on top.

https://claude.ai/code/session_01WKuoEy3uz26MqqtWN8ufuF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily totals now include total duration and a top_exercises breakdown (exercise name, sets, reps, duration). Reps and duration are nullable when zero; empty days show an empty top_exercises array and zero totals.

* **Tests**
  * Updated tests to assert the new total_duration and top_exercises fields and their edge-case behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->