### PR TITLE
docs: prefer git-first governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,10 @@ Prefer `bun run quality:check` for a quick confidence pass and
 ## Pull Requests
 
 - Keep PRs focused and easy to review.
-- Changes to `master` land through pull requests with one approving review plus
-  a passing `merge-gate` status on the PR head commit.
+- Treat Git as the primary workflow. Run local hooks, local review, and
+  `dagger call check --source=.` before pushing or merging.
+- Open a PR when collaboration or visibility helps, not as the only way to
+  satisfy quality gates.
 - Summarize user-visible behavior changes and any env or schema impact.
 - Include screenshots for UI changes.
 - Call out any follow-up work instead of hiding it in the diff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ Prefer `bun run quality:check` for a quick confidence pass and
 ## Pull Requests
 
 - Keep PRs focused and easy to review.
+- Changes to `master` land through pull requests with one approving review plus
+  a passing `merge-gate` status on the PR head commit.
 - Summarize user-visible behavior changes and any env or schema impact.
 - Include screenshots for UI changes.
 - Call out any follow-up work instead of hiding it in the diff.

--- a/README.md
+++ b/README.md
@@ -174,5 +174,7 @@ Conventional Commits + release-please. Merging to `master` auto-creates Release 
 
 Required PR mergeability is tracked by the `merge-gate` status on the PR head
 commit so squash merges do not depend on GitHub's synthetic merge ref.
+Changes to `master` land through pull requests: GitHub requires one approving
+review plus a passing `merge-gate` status on the PR head commit.
 
 See CLAUDE.md "Release Management" for commit format.

--- a/README.md
+++ b/README.md
@@ -172,9 +172,4 @@ Override via `RATE_LIMIT_EXERCISE_PER_MIN`, `RATE_LIMIT_REPORTS_PER_DAY` env var
 
 Conventional Commits + release-please. Merging to `master` auto-creates Release PR. Merging Release PR bumps version + publishes changelog.
 
-Required PR mergeability is tracked by the `merge-gate` status on the PR head
-commit so squash merges do not depend on GitHub's synthetic merge ref.
-Changes to `master` land through pull requests: GitHub requires one approving
-review plus a passing `merge-gate` status on the PR head commit.
-
 See CLAUDE.md "Release Management" for commit format.

--- a/backlog.d/007-tighten-governance-baselines.md
+++ b/backlog.d/007-tighten-governance-baselines.md
@@ -1,7 +1,7 @@
 # Tighten governance baselines
 
 Priority: medium
-Status: blocked
+Status: done
 Estimate: S
 
 ## Goal
@@ -16,18 +16,30 @@ Require PR review and required checks on the default branch so governance matche
 
 ## Oracle
 
-- [ ] [behavioral] Default branch protection requires PR-based changes
-- [ ] [behavioral] Required review and required status checks are enforced
-- [ ] [behavioral] Repository docs reflect the actual policy
+- [x] [behavioral] Default branch protection requires PR-based changes
+- [x] [behavioral] Required review and required status checks are enforced
+- [x] [behavioral] Repository docs reflect the actual policy
 
 ## Notes
 
-GitHub branch protection currently requires only the `merge-gate` status and no
-required PR reviews. This is blocked on repository settings access and owner
-policy decisions.
+Verified and completed on 2026-04-05: repository branch protection requires one
+approving review, the `merge-gate` status check, and now enforces the same rule
+for admins (`enforce_admins: true`).
 
 ## Touchpoints
 
 - GitHub branch protection settings
 - `README.md`
 - `CONTRIBUTING.md`
+
+## What Was Built
+
+- Re-verified the live `master` branch protection settings through the GitHub
+  API instead of trusting the stale backlog note.
+- Enabled admin enforcement on `master` so the PR review and required-check
+  policy cannot be bypassed by repository admins.
+- Updated contributor-facing docs to state that changes to `master` land
+  through pull requests with one approving review and a passing `merge-gate`
+  status on the PR head commit.
+- Closed the backlog item with the verified final policy instead of the stale
+  blocked note.

--- a/backlog.d/007-tighten-governance-baselines.md
+++ b/backlog.d/007-tighten-governance-baselines.md
@@ -1,7 +1,7 @@
 # Tighten governance baselines
 
 Priority: medium
-Status: done
+Status: blocked
 Estimate: S
 
 ## Goal
@@ -16,15 +16,16 @@ Require PR review and required checks on the default branch so governance matche
 
 ## Oracle
 
-- [x] [behavioral] Default branch protection requires PR-based changes
-- [x] [behavioral] Required review and required status checks are enforced
-- [x] [behavioral] Repository docs reflect the actual policy
+- [ ] [behavioral] Default branch protection requires PR-based changes
+- [ ] [behavioral] Required review and required status checks are enforced
+- [ ] [behavioral] Repository docs reflect the actual policy
 
 ## Notes
 
-Verified and completed on 2026-04-05: repository branch protection requires one
-approving review, the `merge-gate` status check, and now enforces the same rule
-for admins (`enforce_admins: true`).
+Owner policy changed on 2026-04-06: for personal projects, GitHub-enforced PR
+reviews and required checks are not the preferred governance model. The desired
+direction is Git-first workflow with local hooks, local `dagger` checks, and
+local agent review, using pull requests only when they materially help.
 
 ## Touchpoints
 
@@ -34,12 +35,9 @@ for admins (`enforce_admins: true`).
 
 ## What Was Built
 
-- Re-verified the live `master` branch protection settings through the GitHub
-  API instead of trusting the stale backlog note.
-- Enabled admin enforcement on `master` so the PR review and required-check
-  policy cannot be bypassed by repository admins.
-- Updated contributor-facing docs to state that changes to `master` land
-  through pull requests with one approving review and a passing `merge-gate`
-  status on the PR head commit.
-- Closed the backlog item with the verified final policy instead of the stale
-  blocked note.
+- Re-opened this item as blocked because the owner no longer wants GitHub
+  branch-protection rules to be the primary quality gate on personal repos.
+- Updated contributor-facing docs to prefer local hooks, local `dagger`
+  verification, and local review over mandatory GitHub PR/ruleset workflow.
+- The remaining GitHub org/repo rules are now an external policy question, not
+  a repository-docs completion.


### PR DESCRIPTION
## Summary
- remove repo docs that treated GitHub PR rules and status checks as the primary governance model
- update `CONTRIBUTING.md` to prefer local hooks, local review, and `dagger call check --source=.` as the main quality gates
- move backlog item `007-tighten-governance-baselines` back to `blocked` because the owner policy is now git-first rather than GitHub-rules-first
- revert the repo-level `enforce_admins` setting on `master`

## Verification
- `gh api repos/misty-step/volume/branches/master/protection/enforce_admins` -> `{"enabled":false}`
- `gh api repos/misty-step/volume/rulesets/12509021 --jq '{current_user_can_bypass, bypass_actors}'`
- `bunx prettier --check README.md CONTRIBUTING.md backlog.d/007-tighten-governance-baselines.md`
- pre-push hooks passed on push (`security-audit`, `architecture-check`, `build-check`, `test-suite`)

## Notes
- This PR intentionally moves policy away from GitHub-enforced PR/review gates for this personal-project workflow.
- It does not remove the org-level ruleset; that remains an external policy decision.
