### PR TITLE
docs: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 misty-step
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -177,3 +177,7 @@ Override via `RATE_LIMIT_EXERCISE_PER_MIN`, `RATE_LIMIT_REPORTS_PER_DAY` env var
 Conventional Commits + release-please. Merging to `master` auto-creates Release PR. Merging Release PR bumps version + publishes changelog.
 
 See CLAUDE.md "Release Management" for commit format.
+
+## License
+
+[MIT](LICENSE)

--- a/backlog.d/004-add-repository-license.md
+++ b/backlog.d/004-add-repository-license.md
@@ -1,7 +1,7 @@
 # Add repository license
 
 Priority: high
-Status: blocked
+Status: done
 Estimate: S
 
 ## Goal
@@ -20,11 +20,16 @@ Add an explicit repository license so documentation reaches a basic legal baseli
 
 ## Notes
 
-This is blocked on license choice. The readiness review found no `LICENSE*`
-file in the repository. The implementation is trivial once the owner selects a
-license.
+Owner selected MIT on 2026-04-23. The readiness review found no `LICENSE*`
+file in the repository.
 
 ## Touchpoints
 
 - `LICENSE`
 - `README.md`
+
+## What Was Built
+
+- Added a root MIT `LICENSE` file.
+- Declared `license: MIT` in `package.json`.
+- Linked the license from `README.md`.

--- a/e2e/error-scenarios.spec.ts
+++ b/e2e/error-scenarios.spec.ts
@@ -60,11 +60,7 @@ test.describe("404 and Navigation Errors", () => {
 });
 
 test.describe("Coach Composer Validation", () => {
-  test("Send action stays disabled for blank input", async ({
-    page,
-    resetUserData,
-  }) => {
-    await resetUserData();
+  test("Send action stays disabled for blank input", async ({ page }) => {
     await openCoachWorkspace(page, "/");
 
     const input = coachInput(page);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "volume",
   "version": "1.18.0",
+  "license": "MIT",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/test/reset/route.test.ts
+++ b/src/app/api/test/reset/route.test.ts
@@ -268,6 +268,84 @@ describe("POST /api/test/reset", () => {
     expect(await response.text()).toBe("Internal Server Error");
   });
 
+  it("retries transient Convex gateway failures during reset", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+
+    authMock.mockResolvedValue({
+      userId: "user_123",
+      getToken: vi.fn().mockResolvedValue("convex-token"),
+    });
+    queryMock
+      .mockRejectedValueOnce(new Error("502 Bad Gateway"))
+      .mockResolvedValueOnce([{ _id: "set_123" }])
+      .mockResolvedValueOnce([]);
+    mutationMock.mockResolvedValue(undefined);
+
+    const setTimeoutMock = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation(((callback: TimerHandler) => {
+        if (typeof callback === "function") {
+          callback();
+        }
+        return 0 as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout);
+
+    try {
+      const { POST } = await import("./route");
+      const response = await POST(createRequest("test-secret"));
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("User data reset");
+      expect(queryMock).toHaveBeenCalledTimes(3);
+      expect(queryMock).toHaveBeenNthCalledWith(1, api.sets.listSets, {});
+      expect(queryMock).toHaveBeenNthCalledWith(2, api.sets.listSets, {});
+      expect(queryMock).toHaveBeenNthCalledWith(
+        3,
+        api.exercises.listExercises,
+        { includeDeleted: true }
+      );
+      expect(mutationMock).toHaveBeenCalledTimes(1);
+      expect(mutationMock).toHaveBeenCalledWith(api.sets.deleteSet, {
+        id: "set_123",
+      });
+    } finally {
+      setTimeoutMock.mockRestore();
+    }
+  });
+
+  it("returns 500 after exhausting transient Convex reset retries", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+
+    authMock.mockResolvedValue({
+      userId: "user_123",
+      getToken: vi.fn().mockResolvedValue("convex-token"),
+    });
+    queryMock.mockRejectedValue(new Error("502 Bad Gateway"));
+
+    const setTimeoutMock = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation(((callback: TimerHandler) => {
+        if (typeof callback === "function") {
+          callback();
+        }
+        return 0 as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout);
+
+    try {
+      const { POST } = await import("./route");
+      const response = await POST(createRequest("test-secret"));
+
+      expect(response.status).toBe(500);
+      expect(await response.text()).toBe("Internal Server Error");
+      expect(queryMock).toHaveBeenCalledTimes(3);
+      expect(mutationMock).not.toHaveBeenCalled();
+    } finally {
+      setTimeoutMock.mockRestore();
+    }
+  });
+
   it("ignores missing resources during reset so concurrent workers stay idempotent", async () => {
     process.env.NODE_ENV = "production";
     process.env.VERCEL_ENV = "preview";

--- a/src/app/api/test/reset/route.ts
+++ b/src/app/api/test/reset/route.ts
@@ -2,13 +2,55 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "@/../convex/_generated/api";
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { reportError } from "@/lib/analytics";
 import { isServerProductionDeployment } from "@/lib/environment";
 import { applyE2ETestSessionCookie } from "@/lib/e2e/test-session";
+import { createChildLogger } from "@/lib/logger";
 
 const TEST_SECRET_HEADER = "X-TEST-SECRET";
+const TRANSIENT_RESET_RETRY_DELAYS_MS = [250, 500];
+const routeLog = createChildLogger({ route: "test/reset" });
 
 function isIgnorableResetError(error: unknown) {
   return error instanceof Error && /not found/i.test(error.message);
+}
+
+function isTransientResetError(error: unknown) {
+  return (
+    error instanceof Error &&
+    /\b502\b|\b503\b|\b504\b|bad gateway|gateway timeout|service unavailable|fetch failed|network error/i.test(
+      error.message
+    )
+  );
+}
+
+async function sleep(ms: number) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function retryTransientResetOperation<T>(operation: () => Promise<T>) {
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      const delayMs = TRANSIENT_RESET_RETRY_DELAYS_MS[attempt];
+      if (!isTransientResetError(error) || delayMs === undefined) {
+        throw error;
+      }
+
+      routeLog.warn("Transient Convex reset failure, retrying", {
+        attempt: attempt + 1,
+        delayMs,
+        error,
+      });
+      attempt += 1;
+      await sleep(delayMs);
+    }
+  }
 }
 
 async function runResetMutation(
@@ -17,7 +59,7 @@ async function runResetMutation(
   args: Parameters<ConvexHttpClient["mutation"]>[1]
 ) {
   try {
-    await convex.mutation(mutation, args);
+    await retryTransientResetOperation(() => convex.mutation(mutation, args));
   } catch (error) {
     // Parallel E2E workers can race while clearing the same authenticated user.
     // Missing records mean another reset already removed the resource.
@@ -31,14 +73,18 @@ async function runResetMutation(
 async function clearAuthenticatedE2EState(convex: ConvexHttpClient) {
   // CI talks to a hosted Convex deployment, so the reset path must only depend
   // on already-deployed public APIs instead of a branch-local test mutation.
-  const sets = await convex.query(api.sets.listSets, {});
+  const sets = await retryTransientResetOperation(() =>
+    convex.query(api.sets.listSets, {})
+  );
   for (const set of sets) {
     await runResetMutation(convex, api.sets.deleteSet, { id: set._id });
   }
 
-  const exercises = await convex.query(api.exercises.listExercises, {
-    includeDeleted: true,
-  });
+  const exercises = await retryTransientResetOperation(() =>
+    convex.query(api.exercises.listExercises, {
+      includeDeleted: true,
+    })
+  );
   for (const exercise of exercises) {
     await runResetMutation(convex, api.exercises.deleteExercise, {
       id: exercise._id,
@@ -85,7 +131,10 @@ export async function POST(request: NextRequest) {
       new NextResponse("User data reset", { status: 200 })
     );
   } catch (error) {
-    console.error("Reset failed:", error);
+    const resetError =
+      error instanceof Error ? error : new Error("Unknown reset error");
+    routeLog.error("Authenticated E2E reset failed", { error: resetError });
+    reportError(resetError, { context: "test/reset" });
     return new NextResponse("Internal Server Error", { status: 500 });
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,9 +3,12 @@ import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from "path";
 
+const testTimeoutMs = process.env.CI === "true" ? 10_000 : 5_000;
+
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
+    testTimeout: testTimeoutMs,
     pool: "forks",
     poolOptions: {
       forks: { maxForks: 4 },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,12 +3,9 @@ import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from "path";
 
-const testTimeoutMs = process.env.CI === "true" ? 10_000 : 5_000;
-
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
-    testTimeout: testTimeoutMs,
     pool: "forks",
     poolOptions: {
       forks: { maxForks: 4 },


### PR DESCRIPTION
# Pull Request

## Description

Adds the root MIT license, aligns repository metadata/docs/backlog with that choice, and hardens `/api/test/reset` against transient hosted Convex `502` responses that were flaking the PR `Flows` job.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Test improvements

## Manual QA Checklist

### Desktop (Chrome/Firefox/Safari)

- [ ] Not applicable: no user-facing desktop UI change

### Mobile (iOS Safari) - CRITICAL

- [ ] Not applicable: no mobile UI change

### Payment/Subscription Changes (if applicable)

- [ ] Not applicable

### External Integration Deployment (if modifying Stripe, Clerk, OpenRouter, etc.)

- [ ] Not applicable

## Test Results

- [x] `bunx vitest run src/app/api/test/reset/route.test.ts` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` succeeds
- [x] pre-push passes: `vitest --coverage --run`, `bun audit --audit-level=high`, `tsx scripts/verify-architecture.ts`, `next build`
- [ ] `bunx playwright test e2e/subscription-flow.spec.ts e2e/error-scenarios.spec.ts` is blocked locally because CI-only Clerk/Convex E2E env vars are unavailable in this workspace; validated in GitHub Actions `Flows`

## Screenshots (if applicable)

Not applicable.

Ships backlog:004


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MIT license file and linked it from the README
  * Updated backlog entry to note license selection and completion

* **Chores**
  * Declared repository license in project metadata

* **Reliability**
  * Reset operation now retries on transient gateway/network errors and reports errors more consistently

* **Tests**
  * Added tests covering reset retry behavior and simplified one end-to-end test setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->